### PR TITLE
Don't install fscomp-libconfig.json into subdir

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -32,7 +32,7 @@ TARGET_FLAGS = {
 }
 
 def libconfig_builder(env):
-    env.Install('fscomp-libconfig.json', '#fscomp-libconfig.json')
+    env.Install('.', '#fscomp-libconfig.json')
 
 def libconfig_parser():
     return '$ARCHBUILDDIR/components/asynchttp/.fscomp/libconfig'


### PR DESCRIPTION
First argument to env.Install takes a directory into which the specified
file should be installed. Change the argument to '.' to install it in
the folder where it's expected to be.