### PR TITLE
Fix double free with proxy_host in client.c

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -251,6 +251,7 @@ void http_client_set_direct(http_client_t *client)
 {
     FSTRACE(ASYNCHTTP_CLIENT_SET_DIRECT, client->uid);
     fsfree(client->proxy_host);
+    client->proxy_host = NULL;
     client->proxy_mode = PROXY_DIRECT;
     flush_free_conn_pool(client);
     prevent_recycling_of_ops_in_flight(client);
@@ -262,6 +263,7 @@ void http_client_use_system_proxy(http_client_t *client)
 {
     FSTRACE(ASYNCHTTP_CLIENT_SET_DIRECT, client->uid);
     fsfree(client->proxy_host);
+    client->proxy_host = NULL;
     client->proxy_mode = PROXY_SYSTEM;
     flush_free_conn_pool(client);
     prevent_recycling_of_ops_in_flight(client);


### PR DESCRIPTION
Double free with http_client_t occured with this action sequence:
1. Set http_client_t to use explicit proxy
2. Set http_client_t to use system proxy
  - This frees memory of proxy_host but proxy_host still points to same
    memory address

After this any action that would cause http_client_t to free proxy_host
depending on whether it's NULL or not will execute fsfree and trigger
segmentation fault:
- closing http_client
- making any proxy change

This commit fixes the issue by setting proxy_host to NULL after it's
freed in places where it isn't already set to some new value.