### PR TITLE
Give http_client_close and http_op_close more robust semantics

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -19,6 +19,9 @@ http_client_t *open_http_client_2(async_t *async, fsadns_t *dns);
 
 /* Equivalent to open_http_client_2(async, NULL). */
 http_client_t *open_http_client(async_t *async);
+
+/* A client can be closed before the operations are closed, but the
+ * operations must be closed separately. */
 void http_client_close(http_client_t *client);
 
 /* Set the maximum size for the response headers accepted from the
@@ -108,7 +111,9 @@ int http_op_get_response_content(http_op_t *op, bytestream_1 *content);
 void http_op_register_callback(http_op_t *op, action_1 action);
 void http_op_unregister_callback(http_op_t *op);
 
-/* An operation can be closed before it has been received. */
+/* An operation can be closed before it has been received. If
+ * http_op_receive_response() has returned content, it must be closed
+ * separately. */
 void http_op_close(http_op_t *op);
 
 #ifdef __cplusplus

--- a/test/webclient.c
+++ b/test/webclient.c
@@ -70,6 +70,7 @@ static void probe_content(globals_t *g)
             break;
         }
     }
+    bytestream_1_close(g->content);
     http_op_close(g->request);
     if (g->success && g->spam >= 0)
         async_timer_start(g->async, async_now(g->async) + g->spam,


### PR DESCRIPTION
client.h didn't document clearly what would happen if http_client_close were called while operations were in flight or if http_op_close were called before the response body was closed. The implementation courtesy-closed such operations and body contents, but that choice was ill-advised and not compliant with modern async practices, which maintain proper reference counting.

Technically, this change is not fully backward-compatible and will break applications that depend on the previous courtesy-close semantics. It is estimated, though, that such applications do not exist at the moment.