### PR TITLE
webclient: remove incorrect validation of --spam argument

### DIFF
--- a/test/webclient.c
+++ b/test/webclient.c
@@ -273,7 +273,7 @@ static int parse_cmdline(int argc, const char *const argv[], args_t *args)
             const char *start = argv[i++];
             char *end;
             double interval = strtod(start, &end);
-            if (start == end || interval < 0 || interval > INT64_MAX)
+            if (start == end || interval < 0)
                 bad_usage();
             args->spam = (int64_t) (interval * ASYNC_S);
             continue;


### PR DESCRIPTION
This commit fixes compilation with clang, which generates the warning

error: implicit conversion from 'long' to 'double' changes value from
9223372036854775807 to 9223372036854775808
[-Werror,-Wimplicit-int-float-conversion]

for the conversion of INT64_MAX to double. Implementing a proper test
to verify that 'interval * ASYNC_S' does not overflow and can be
represented as an int64_t is not worth the effort.