### PR TITLE
jsonop: Decode response on != 200 responses

### DIFF
--- a/include/jsonop.h
+++ b/include/jsonop.h
@@ -23,6 +23,10 @@ jsonop_t *jsonop_make_request(async_t *async, http_client_t *client,
 jsonop_t *jsonop_make_get_request(async_t *async, http_client_t *client,
                                   const char *uri);
 
+/* When this function is called, jsonop will decode the response also when
+ * response code != 200. */
+void jsonop_decode_response_on_error(jsonop_t *op);
+
 /* Set or cancel a maximum expected duration for the operation. See
  * http_op_set_timeout() and http_op_cancel_timeout() for the
  * semantics. */
@@ -42,9 +46,13 @@ const http_env_t *jsonop_response_headers(jsonop_t *op);
  * closed the connection without a response. */
 int jsonop_response_code(jsonop_t *op);
 
-/* The response body is available only if jsonop_response_code() returns
- * 200. The returned value is for inspection only and continues to be
- * owned by the JSON operation. */
+/* The response body is available only if:
+ * - jsonop_response_code() returns 200 or
+ * - jsonop_decode_response_on_error() has been called and
+ *   json_op_response_code() returns > 0.
+ *
+ * The returned value is for inspection only and continues to be owned by the
+ * JSON operation. */
 json_thing_t *jsonop_response_body(jsonop_t *op);
 
 void jsonop_close(jsonop_t *op);


### PR DESCRIPTION
Add a new method that users can use to indicate that the backend
responds with json body also on != 200 responses. And then users can use
the same jsonop_response_body() method to get the decoded json response.