### PR TITLE
Fix timeout unit test to actually fail test

### DIFF
--- a/scripts/run-unittests.sh
+++ b/scripts/run-unittests.sh
@@ -69,7 +69,7 @@ test-client-file-bundle() {
 }
 
 test-jsonop() {
-    local arch=$1
+    local arch=$1 status
     set +e
     run-test \
         $arch \
@@ -77,8 +77,9 @@ test-jsonop() {
         --json \
         --timeout 1 \
         http://echo.jsontest.com/key/value
-    [ $? -eq 1 ] || return 1
+    status=$?
     set -e
+    [ $status -eq 1 ]
     run-test > stage/$arch/body \
         $arch \
         ./stage/$arch/build/test/webclient \


### PR DESCRIPTION
Previously if the json request with --timeout 1 actually worked, unit
tests didn't fail.