### PR TITLE
test: fix SAN type of the test certificate

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -60,7 +60,7 @@ def create_certificate(stem, CA):
     cert_path = stem + ".pem"
     config_path = stem + ".cnf"
     with open(config_path, "w") as f:
-        f.write("subjectAltName = DNS:127.0.0.1")
+        f.write("subjectAltName = IP:127.0.0.1")
     csr_path, key_path = create_csr(stem)
     cmd = (
         "openssl",


### PR DESCRIPTION
OpenSSL 3.0 seems to be more strict with it