### PR TITLE
Don't call again_or_timeout on the success path

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -961,7 +961,8 @@ const http_env_t *http_op_receive_response(http_op_t *op)
             errno = 0; /* pseudo-EOF */
             response = NULL;
     }
-    errno = again_or_timeout(op, errno);
+    if (!response)
+        errno = again_or_timeout(op, errno);
     FSTRACE(ASYNCHTTP_OP_RECEIVED, op->uid, response);
     return response;
 }


### PR DESCRIPTION
On the success path, errno may contain a stale EAGAIN, causing again_or_timeout to advance timer_state from EXPIRED to REPORTED. A subsequent http_op_get_response_content call checks timer_state first and returns ETIMEDOUT if it sees REPORTED -- even though the response headers were received successfully.